### PR TITLE
Fix default GitCleaner maxAge: 12 minutes -> 12 hours

### DIFF
--- a/src/main/java/fi/abo/kogni/soile2/datamanagement/cleanup/GitCleaner.java
+++ b/src/main/java/fi/abo/kogni/soile2/datamanagement/cleanup/GitCleaner.java
@@ -48,7 +48,7 @@ public class GitCleaner {
 	 */
 	public GitCleaner(MongoClient client, Vertx vertx, ElementManager<Task> taskManager) {
 		// default maxAge is 12 hours
-		this(client,vertx,taskManager, 1000*60*12);
+		this(client,vertx,taskManager, 1000*60*60*12);
 	}
 	/**
 	 * Create a GitCleaner with a specified maxAge. The maxAge indicates how old a version can be to still be


### PR DESCRIPTION
## Summary
The parameterless-`maxAge` `GitCleaner` constructor documents a default
`maxAge` of **12 hours** (constructor Javadoc and inline comment), but the
supplied value `1000*60*12` evaluates to **12 minutes**.

`maxAge` is compared in milliseconds against `versionAge`
(`currentTime - version date`, both from `getTime()`), so 12 hours should be
`1000*60*60*12`. As written, the default grace period was 12 minutes instead
of the intended 12 hours.

## Effect
`maxAge` is the grace period that keeps recently-edited task versions from
being cleaned up (the assumption being they may still be under active work).
When the default constructor is used, that window was only 12 minutes — far
short of the documented 12 hours — so versions a researcher edited within the
last several hours could be considered unreachable and purged.

Note: this is a latent correctness fix. The default constructor is currently
only exercised by the test suite, and automatic cleanup is not yet wired into
the running application, so there is no active production failure today. The
change aligns the code with its documented intent and protects the moment the
cleaner is wired up with the default constructor.

## Change
One-line fix in `GitCleaner.java`:

```diff
- this(client,vertx,taskManager, 1000*60*12);
+ this(client,vertx,taskManager, 1000*60*60*12);
